### PR TITLE
Taxa reference table

### DIFF
--- a/R/01_Data_processing/03_Merging_and_geography/01_Merge_datasets.R
+++ b/R/01_Data_processing/03_Merging_and_geography/01_Merge_datasets.R
@@ -77,7 +77,8 @@ user_name_patterns <- NULL
 data_clean_names <-
   RFossilpol::proc_clean_count_names(
     data_source = data_full_filtered,
-    additional_patterns = user_name_patterns
+    additional_patterns = user_name_patterns,
+    dir = data_storage_path # [config_criteria]
   )
 
 


### PR DESCRIPTION
# Taxa reference table
- in order to link Neotoma taxa to the harmonisation table, a reference table is needed.
- add `data_storage_path` to `proc_clean_count_names`
- linked to HOPE-UIB-BIO/R-Fossilpol-package#36